### PR TITLE
add extraploate function in GEMDigiMatcher and RPCDigiMatcher, 

### DIFF
--- a/GEMValidation/src/GEMDigiMatcher.h
+++ b/GEMValidation/src/GEMDigiMatcher.h
@@ -74,6 +74,8 @@ public:
   std::set<int> padNumbersInDetId(unsigned int) const;
   std::set<int> coPadNumbersInDetId(unsigned int) const;
 
+  int extrapolateHsfromGEMPad(unsigned int , int ) const;
+  int extrapolateHsfromGEMStrip(unsigned int , int ) const;
   // what unique partitions numbers with digis from this simtrack?
   std::set<int> partitionNumbers() const;
   std::set<int> partitionNumbersWithCoPads() const;

--- a/GEMValidation/src/RPCDigiMatcher.h
+++ b/GEMValidation/src/RPCDigiMatcher.h
@@ -43,7 +43,9 @@ public:
   /// How many pads in RPC did this simtrack get in total?
   int nStrips() const;
 
+  int extrapolateHsfromRPC(unsigned int, int) const; 
 
+  
   std::set<int> stripsInDetId(unsigned int) const;
 
   // what unique partitions numbers with digis from this simtrack?


### PR DESCRIPTION
add extraploate function in GEMDigiMatcher and RPCDigiMatcher,  and add several branches in tree in analyzer to fill the halfstrip extrapolated from GEM and RPC
