### PR TITLE
Update step2_ReL1_Run3_MuonShower.py

### DIFF
--- a/GEMValidation/test/step2_ReL1_Run3_MuonShower.py
+++ b/GEMValidation/test/step2_ReL1_Run3_MuonShower.py
@@ -205,7 +205,7 @@ if not options.run3:
 process.simCscTriggerPrimitiveDigis.commonParam.runME11ILT =False
 process.simCscTriggerPrimitiveDigisCath = process.simCscTriggerPrimitiveDigis.clone()
 process.simCscTriggerPrimitiveDigisAnod = process.simCscTriggerPrimitiveDigis.clone()
-process.simCscTriggerPrimitiveDigis.showerParam.source =2
+process.simCscTriggerPrimitiveDigis.showerParam.source =3
 process.simCscTriggerPrimitiveDigisCath.showerParam.source =0
 process.simCscTriggerPrimitiveDigisAnod.showerParam.source =1
 process.simEmtfShowersCath = process.simEmtfShowers.clone()


### PR DESCRIPTION
The showers which trigger the logic for a given chamber must pass an AND between cathode and anode thresholds:

https://github.com/cms-sw/cmssw/blob/CMSSW_12_5_X/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py

Note that showerParam.source =3 was introduced from CMSSW_12_2_X on. Before that, the same logic was set with showerParam.source =2, so it needs to be updated.